### PR TITLE
MaxDistance check during displacement calculation

### DIFF
--- a/src/main/java/org/terasology/fireball/FireballCollisionHandler.java
+++ b/src/main/java/org/terasology/fireball/FireballCollisionHandler.java
@@ -35,14 +35,14 @@ public class FireballCollisionHandler extends BaseComponentSystem {
         int oldTargetHealth = targetEntity.getComponent(HealthComponent.class).currentHealth;
         targetEntity.send(new DoDamageEvent(health.currentHealth, projectile.damageType));
         int newTargetHealth = 0;
-        if(targetEntity.exists())
+        if (targetEntity.exists())
             newTargetHealth = targetEntity.getComponent(HealthComponent.class).currentHealth;
         // inflict same amount of damage on fireball as on the target
         entity.send(new DoDamageEvent(oldTargetHealth - newTargetHealth, projectile.damageType));
 
-        if(entity.exists()) {
+        if (entity.exists()) {
             ParticleEmitterComponent particleEmitter = entity.getComponent(ParticleEmitterComponent.class);
-            particleEmitter.maxParticles -= (oldTargetHealth - newTargetHealth)/health.maxHealth
+            particleEmitter.maxParticles -= (oldTargetHealth - newTargetHealth) / health.maxHealth
                     * particleEmitter.spawnRateMax;
         }
 

--- a/src/main/java/org/terasology/fireball/FireballParticleHandlerSystem.java
+++ b/src/main/java/org/terasology/fireball/FireballParticleHandlerSystem.java
@@ -52,7 +52,7 @@ public class FireballParticleHandlerSystem extends BaseComponentSystem {
 
         AttractorAffectorComponent attractorAffector = new AttractorAffectorComponent();
         attractorAffector.origin = entity.getComponent(LocationComponent.class);
-        attractorAffector.attractors.put(new Vector3f(0, 0,0), -.1f);
+        attractorAffector.attractors.put(new Vector3f(0, 0, 0), -.1f);
         attractorAffector.attractors.put(new Vector3f(negDirection).scale(.1f), -.3f);
 
         entity.addComponent(attractorAffector);
@@ -62,7 +62,6 @@ public class FireballParticleHandlerSystem extends BaseComponentSystem {
         entity.send(new ParticleSystemUpdateEvent());
         entity.removeComponent(MeshComponent.class);
     }
-
 
 
 }

--- a/src/main/java/org/terasology/projectile/HitTargetEvent.java
+++ b/src/main/java/org/terasology/projectile/HitTargetEvent.java
@@ -30,7 +30,7 @@ public class HitTargetEvent extends AbstractConsumableEvent {
     private int activationId;
 
     public HitTargetEvent(EntityRef target, EntityRef instigator, Vector3f origin, Vector3f direction,
-                         Vector3f hitPosition, Vector3f hitNormal) {
+                          Vector3f hitPosition, Vector3f hitNormal) {
         this.instigator = instigator;
         this.target = target;
         this.direction = direction;

--- a/src/main/java/org/terasology/projectile/ProjectileActionComponent.java
+++ b/src/main/java/org/terasology/projectile/ProjectileActionComponent.java
@@ -20,7 +20,7 @@ import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.logic.health.EngineDamageTypes;
 import org.terasology.math.geom.Vector3f;
 
-public class ProjectileActionComponent implements Component{
+public class ProjectileActionComponent implements Component {
     /**
      * scaling the projectile icon
      */

--- a/src/main/java/org/terasology/projectile/ProjectileAuthoritySystem.java
+++ b/src/main/java/org/terasology/projectile/ProjectileAuthoritySystem.java
@@ -128,10 +128,11 @@ public class ProjectileAuthoritySystem extends BaseComponentSystem implements Up
             ProjectileMotionComponent projectileMotion = entity.getComponent(ProjectileMotionComponent.class);
 
             if (projectileMotion.distanceTravelled >= projectile.maxDistance && projectile.maxDistance != -1) {
-                if (projectile.reusable)
+                if (projectile.reusable) {
                     entity.send(new DeactivateProjectileEvent());
-                else
+                } else {
                     entity.destroy();
+                }
                 continue;
             }
 

--- a/src/main/java/org/terasology/projectile/ProjectileMotionComponent.java
+++ b/src/main/java/org/terasology/projectile/ProjectileMotionComponent.java
@@ -21,7 +21,7 @@ import org.terasology.math.geom.Vector3f;
 /**
  * Component attached to projectiles which are in state of motion ,i.e have been fired.
  */
-public class ProjectileMotionComponent implements Component{
+public class ProjectileMotionComponent implements Component {
 
     /**
      * The current velocity of projectile.


### PR DESCRIPTION
Issue:
A projectile launched is checked for the `distanceTravelled > maxDistance` in the start of the `update` method and then the new displacement (based on `delta` and `velocity`) is added on top. This works well unless there is a lag. When there is a lag, the delta is usually too high, which means that the displacement that gets added on top may exceed the maxDistance permitted for that projectile. This would result in the projectile traveling a greater distance than allowed and destroying things on the way. The said projectile would only get destroyed in the next tick.

Solution:
Added a check to ensure that the displacement that gets added on top never lets the projectile exceed its maxDistance.
```
float displacement = Math.min(projectileMotion.currentVelocity.length() * delta,
                    projectile.maxDistance - projectileMotion.distanceTravelled);
```